### PR TITLE
fix a discrepancy in the command match during affected commands update

### DIFF
--- a/editor/src/app/state/enums/actions.ts
+++ b/editor/src/app/state/enums/actions.ts
@@ -31,6 +31,7 @@ export const renameGameEnum = createAction(
     game: Game;
     newEnumName: string;
     oldEnumName: string;
+    isAffected: boolean;
   }>()
 );
 

--- a/editor/src/app/state/enums/effects.ts
+++ b/editor/src/app/state/enums/effects.ts
@@ -81,6 +81,7 @@ export class EnumsEffects {
           game,
           newEnumName: enumToEdit.name,
           oldEnumName: oldEnumToEdit.name,
+          isAffected: false
         })
       )
     )

--- a/editor/src/app/state/extensions/actions.ts
+++ b/editor/src/app/state/extensions/actions.ts
@@ -5,6 +5,7 @@ export interface GameCommandUpdate {
   command: Command;
   newExtension: string;
   oldExtension: string;
+  ignoreVersionAndPlatform: boolean;
 }
 
 export const init = createAction('[extensions] init');

--- a/editor/src/app/state/extensions/effects.ts
+++ b/editor/src/app/state/extensions/effects.ts
@@ -126,14 +126,16 @@ export class ExtensionsEffects {
                         command,
                         newExtension,
                         oldExtension,
+                        ignoreVersionAndPlatform: d.game !== game,
                       }));
                     } else {
-                      return {
+                      return [{
                         game,
                         command,
                         newExtension,
                         oldExtension,
-                      };
+                        ignoreVersionAndPlatform: false,
+                      }];
                     }
                   })
                 );
@@ -145,6 +147,7 @@ export class ExtensionsEffects {
                   command,
                   newExtension,
                   oldExtension,
+                  ignoreVersionAndPlatform: false,
                 },
               ]);
             }
@@ -198,7 +201,7 @@ export class ExtensionsEffects {
   renameEnum$ = createEffect(() =>
     this._actions$.pipe(
       ofType(renameGameEnum),
-      switchMap(({ game, oldEnumName, newEnumName }) =>
+      switchMap(({ game, oldEnumName, newEnumName, isAffected }) =>
         this._extensions.getGameExtensions(game).pipe(
           // take(1),
           switchMap((extensions) => {
@@ -224,6 +227,9 @@ export class ExtensionsEffects {
                   },
                 }))
             );
+            if (isAffected) {
+              return of({ affectedCommands, otherGames: [] });
+            }
             return zip(
               ...affectedCommands.map(({ extension, command }) => {
                 return this._extensions.getCommandSupportInfo(
@@ -254,6 +260,7 @@ export class ExtensionsEffects {
               game,
               batch: affectedCommands.map(({ extension, command }) => ({
                 command,
+                ignoreVersionAndPlatform: isAffected,
                 oldExtension: extension,
                 newExtension: extension,
               })),
@@ -263,6 +270,7 @@ export class ExtensionsEffects {
                 game: otherGame,
                 newEnumName,
                 oldEnumName,
+                isAffected: true,
               })
             ),
           ])
@@ -316,6 +324,7 @@ export class ExtensionsEffects {
               },
               newExtension: extension,
               oldExtension: extension,
+              ignoreVersionAndPlatform: false,
             },
           ],
         }),

--- a/editor/src/app/state/extensions/facade.ts
+++ b/editor/src/app/state/extensions/facade.ts
@@ -68,7 +68,7 @@ export class ExtensionsFacade {
   }) {
     this.store$.dispatch(
       updateCommands({
-        batch: [{ command, newExtension, oldExtension }],
+        batch: [{ command, newExtension, oldExtension, ignoreVersionAndPlatform: false }],
       })
     );
   }

--- a/editor/src/app/state/extensions/reducer.ts
+++ b/editor/src/app/state/extensions/reducer.ts
@@ -60,7 +60,15 @@ export const extensionsReducer = createReducer(
   ),
   on(updateGameCommands, (state, { game, batch }) => {
     const extensions: Extension[] = batch.reduce(
-      (memo, { command: newCommand, newExtension: name, oldExtension }) => {
+      (
+        memo,
+        {
+          command: newCommand,
+          newExtension: name,
+          oldExtension,
+          ignoreVersionAndPlatform,
+        }
+      ) => {
         memo = upsertBy(
           memo,
           (extension) => extension.name === name,
@@ -69,7 +77,8 @@ export const extensionsReducer = createReducer(
             ...e,
             commands: upsertBy(
               e.commands,
-              (command) => commandMatcher(command, newCommand),
+              (command) =>
+                commandMatcher(command, newCommand, ignoreVersionAndPlatform),
               'id',
               () => (newCommand.id && newCommand.name ? newCommand : null),
               () => (newCommand.id && newCommand.name ? newCommand : null)
@@ -93,7 +102,8 @@ export const extensionsReducer = createReducer(
           (e) => {
             const commands = upsertBy(
               e.commands,
-              (command) => commandMatcher(command, newCommand),
+              (command) =>
+                commandMatcher(command, newCommand, ignoreVersionAndPlatform),
               'id'
             );
             if (!commands.length) {
@@ -240,7 +250,14 @@ function getEntities(
   }, {} as Record<string, Entity[]>);
 }
 
-function commandMatcher(a: Command, b: Command) {
+function commandMatcher(
+  a: Command,
+  b: Command,
+  ignoreVersionAndPlatform: boolean
+) {
+  if (ignoreVersionAndPlatform) {
+    return a.id === b.id;
+  }
   return (
     a.id === b.id &&
     matchArrays(a.versions, b.versions) &&


### PR DESCRIPTION
there is a discrepancy in `getSameCommands` and `commandMatcher`. If the command has extra version/platform tags it won't be matched with `commandMatcher` even if `getSameCommands` marked it as affected.

The issue can be observed in the commit https://github.com/sannybuilder/library/commit/009c48b1dde97a5735bcdffc7223dd3e56760274 where a change introduced duplicate records as `commandMatcher` haven't found a match because the commands had extra version/platform tags.

This PR fixes it by removing the check for platform and version tags for affected commands update.