### PR TITLE
Add "Zone" enum to enums.json for VC DE

### DIFF
--- a/vc_unreal/enums.json
+++ b/vc_unreal/enums.json
@@ -1042,5 +1042,19 @@
   "PadId": {
     "Pad1": 0,
     "Pad2": 1
-  }
+  },
+  "Zone": {
+  "EscobarInternational" : "A_PORT",
+  "OceanBeach" : "BEACH1",
+  "WashingtonBeach" : "BEACH2",
+  "VicePoint" : "BEACH3",
+  "Viceport" : "DOCKS",
+  "Downtown" : "DTOWN",
+  "LeafLinks" : "GOLFC",
+  "LittleHaiti" : "HAITI",
+  "LittleHavana" : "HAVANA",
+  "JunkYard" : "JUNKY",
+  "PrawnIsland" : "PORNI",
+  "StarfishIsland" : "STARI"
+ }
 }


### PR DESCRIPTION
I've created a Zone enum for the functions that need "zone_key" as a parameter(like opcode 0121). Values are taken from the main.scm file in Vice City DE.